### PR TITLE
add assign_shards()

### DIFF
--- a/analysis-reformat/00-PARAMS.R
+++ b/analysis-reformat/00-PARAMS.R
@@ -12,6 +12,7 @@ if(TN_ONLY) SAMPLES_ROOT <- file.path(SAMPLES_ROOT, 'TN')
 NITER = 3000
 NTHIN = 2
 NCHAINS = 4
+NSHARDS = 4
 WARMUP = (NITER/NTHIN)/2
 WARMUP = 500 # WARMUP is number of retained (after thinning) samples
 NNODES = ifelse(Sys.info()[["nodename"]] == 'quetelet',

--- a/analysis-reformat/01-run_all_states.R
+++ b/analysis-reformat/01-run_all_states.R
@@ -42,6 +42,8 @@ county_df <- proc_county(
 
 covid_df <- remove_prisons(covid_df, county_df)
 
+shard_df <- assign_shards(covid_df, county_df, n_shards = NSHARDS)
+
 date_df <- tibble(
   date = seq.Date(from=as.Date(DATE_0),
                   t = max(covid_df$date)+TPRED,


### PR DESCRIPTION
Currently the assign_shards() function returns the `county_df` with the assigned shard column, if you want it to return the `covid_df` with the assigned shard column just uncomment the line at the end of the function.

states will be assigned up to `NSHARDS`, but some will have less than that since its the most they could get broken apart given the constraints. For example states like Delaware and Rhode Island always get 1 since they are all the same group.